### PR TITLE
feature: preprocessing to MMMTrack representation

### DIFF
--- a/src/audio_preprocessing/preprocessing.py
+++ b/src/audio_preprocessing/preprocessing.py
@@ -1,0 +1,44 @@
+from sortedcontainers import SortedList
+
+def note_sequence_to_text(notes):
+    text = "PIECE_START"
+
+    sorted_lists = {}
+
+    for note in notes:
+        current_instrument = note.instrument
+        current_note = note.pitch
+        current_start_time = note.start_time
+        current_end_time = note.end_time
+        current_bar = current_start_time//2
+
+        sorted_list = sorted_lists.setdefault(current_instrument, SortedList())
+
+        sorted_list.add((current_bar, current_start_time, f'NOTE_ON={current_note}'))
+        sorted_list.add((current_bar, current_end_time, f'NOTE_OFF={current_note}'))    
+
+    for instrument, sorted_list in sorted_lists.items():
+        # TODO fill density
+        text += f' TRACK_START INST={instrument} DENSITY=0 BAR_START'
+        time_slider = 0    
+        current_bar = 0
+
+        for el in sorted_list:
+            event_bar, event_time, event = el
+
+            while event_bar != current_bar:
+                current_bar = current_bar + 1
+                text += ' BAR_END BAR_START'
+                time_slider = current_bar*2
+
+            delta_value = (event_time - time_slider)*8.0
+
+            if delta_value > 0:
+                text += f' TIME_DELTA={delta_value}'
+
+            text += f' {event}'
+            time_slider = event_time
+
+        text += f' BAR_END TRACK_END'
+    text += ' PIECE_END\n'
+    return text

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+import sys
+sys.path.append('./src')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,75 @@
+import note_seq
+
+NOTE_LENGTH_16TH_120BPM = 0.25 * 60 / 120
+BAR_LENGTH_120BPM = 4.0 * 60 / 120
+
+def empty_note_sequence(qpm=120.0, total_time=0.0):
+    note_sequence = note_seq.protobuf.music_pb2.NoteSequence()
+    note_sequence.tempos.add().qpm = qpm
+    note_sequence.ticks_per_quarter = note_seq.constants.STANDARD_PPQ
+    note_sequence.total_time = total_time
+    return note_sequence
+
+def token_sequence_to_note_sequence(token_sequence, use_program=True, use_drums=True):
+
+    if isinstance(token_sequence, str):
+        token_sequence = token_sequence.split()
+
+    note_sequence = empty_note_sequence()
+    current_program = 1
+    current_is_drum = False
+    for token_index, token in enumerate(token_sequence):
+
+        if token == "PIECE_START":
+            pass
+        elif token == "PIECE_END":
+            print("The end.")
+            break
+        elif token == "TRACK_START":
+            current_bar_index = 0
+            pass
+        elif token == "TRACK_END":
+            pass
+        elif token.startswith("INST"):
+            current_instrument = token.split("=")[-1]
+            if current_instrument != "DRUMS" and use_program:
+                current_instrument = int(current_instrument)
+                current_program = int(current_instrument)
+                current_is_drum = False
+            if current_instrument == "DRUMS" and use_drums:
+                current_instrument = 0
+                current_program = 0
+                current_is_drum = True
+        elif token == "BAR_START":
+            current_time = current_bar_index * BAR_LENGTH_120BPM
+            current_notes = {}
+        elif token == "BAR_END":
+            current_bar_index += 1
+            pass
+        elif token.startswith("NOTE_ON"):
+            pitch = int(token.split("=")[-1])
+            note = note_sequence.notes.add()
+            note.start_time = current_time
+            note.end_time = current_time + 4 * NOTE_LENGTH_16TH_120BPM
+            note.pitch = pitch
+            note.instrument = int(current_instrument)
+            note.program = current_program
+            note.velocity = 80
+            note.is_drum = current_is_drum
+            current_notes[pitch] = note
+        elif token.startswith("NOTE_OFF"):
+            pitch = int(token.split("=")[-1])
+            if pitch in current_notes:
+                note = current_notes[pitch]
+                note.end_time = current_time
+        elif token.startswith("TIME_DELTA"):
+            delta = float(token.split("=")[-1]) * NOTE_LENGTH_16TH_120BPM
+            current_time += delta
+        elif token.startswith("DENSITY="):
+            pass
+        elif token == "[PAD]":
+            pass
+        else:
+            assert False, token
+
+    return note_sequence

--- a/tests/test_audio_preprocessing_preprocessing.py
+++ b/tests/test_audio_preprocessing_preprocessing.py
@@ -1,0 +1,52 @@
+import pytest
+
+from tests.helpers import *
+from src.audio_preprocessing.preprocessing import note_sequence_to_text
+
+def test_note_sequence_to_text1():
+    # simple note shifted 1sec to right
+    original = 'PIECE_START TRACK_START INST=0 DENSITY=0 BAR_START TIME_DELTA=8.0 NOTE_ON=69 TIME_DELTA=8.0 NOTE_OFF=69 BAR_END TRACK_END PIECE_END\n'
+    original_note_sequence = token_sequence_to_note_sequence(original, use_program=False)
+
+    reencoded = note_sequence_to_text(original_note_sequence.notes)
+
+    assert original == reencoded
+
+
+def test_note_sequence_to_text2():
+    # multiple simultanuous notes shifted 1 sec
+    original = 'PIECE_START TRACK_START INST=1 DENSITY=0 BAR_START NOTE_ON=50 TIME_DELTA=8.0 NOTE_ON=53 TIME_DELTA=8.0 NOTE_OFF=50 TIME_DELTA=8.0 NOTE_OFF=53 BAR_END BAR_START NOTE_ON=57 TIME_DELTA=8.0 NOTE_ON=48 TIME_DELTA=8.0 NOTE_OFF=57 TIME_DELTA=8.0 NOTE_OFF=48 BAR_END TRACK_END PIECE_END\n'
+    original_note_sequence = token_sequence_to_note_sequence(original, use_program=False)
+
+    reencoded = note_sequence_to_text(original_note_sequence.notes)
+
+    assert original == reencoded
+
+def test_note_sequence_to_text3():
+    # one note is played while the other one is being played (starts later, ends earlier)
+    original = 'PIECE_START TRACK_START INST=0 DENSITY=0 BAR_START TIME_DELTA=8.0 NOTE_ON=69 TIME_DELTA=2.0 NOTE_ON=59 TIME_DELTA=4.0 NOTE_OFF=59 TIME_DELTA=2.0 NOTE_OFF=69 BAR_END TRACK_END PIECE_END\n'
+    original_note_sequence = token_sequence_to_note_sequence(original, use_program=False)
+
+    reencoded = note_sequence_to_text(original_note_sequence.notes)
+
+    assert original == reencoded
+
+
+def test_note_sequence_to_text4():
+    # the piece starts from 4th bar
+    original = 'PIECE_START TRACK_START INST=0 DENSITY=0 BAR_START BAR_END BAR_START BAR_END BAR_START TIME_DELTA=8.0 NOTE_ON=69 TIME_DELTA=2.0 NOTE_ON=59 TIME_DELTA=4.0 NOTE_OFF=59 TIME_DELTA=2.0 NOTE_OFF=69 BAR_END TRACK_END PIECE_END\n'
+    original_note_sequence = token_sequence_to_note_sequence(original, use_program=False)
+
+    reencoded = note_sequence_to_text(original_note_sequence.notes)
+
+    assert original == reencoded
+
+
+def test_note_sequence_to_text5():
+    # Same case 4 with two tracks
+    original = 'PIECE_START TRACK_START INST=0 DENSITY=0 BAR_START BAR_END BAR_START BAR_END BAR_START TIME_DELTA=8.0 NOTE_ON=69 TIME_DELTA=2.0 NOTE_ON=59 TIME_DELTA=4.0 NOTE_OFF=59 TIME_DELTA=2.0 NOTE_OFF=69 BAR_END TRACK_END TRACK_START INST=1 DENSITY=0 BAR_START BAR_END BAR_START BAR_END BAR_START TIME_DELTA=8.0 NOTE_ON=69 TIME_DELTA=2.0 NOTE_ON=59 TIME_DELTA=4.0 NOTE_OFF=59 TIME_DELTA=2.0 NOTE_OFF=69 BAR_END TRACK_END PIECE_END\n'
+    original_note_sequence = token_sequence_to_note_sequence(original, use_program=False)
+
+    reencoded = note_sequence_to_text(original_note_sequence.notes)
+    assert original == reencoded
+


### PR DESCRIPTION
# Description

This PR adds source code for preprocessing midi files to MMMTrack representation.  Also adds `requirements.txt` file

# How Has This Been Tested?

The codes has been tested in two ways:

- Using test cases:
![image](https://user-images.githubusercontent.com/18456186/188297616-6ed7fef1-0f2c-4d5f-8d71-67548253ab4a.png)
- Using `token_sequence_to_note_sequence` from [MMM-SJB](https://github.com/AI-Guru/MMM-JSB) repository. The midi files have been converted to note sequence using third party tools, converted to MMMTrack representation using the codes in this PR, converted back to note sequence using  `token_sequence_to_note_sequence` and compared visually and audibly.

To run test cases, run 

```pytest```

 in the home directory.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
